### PR TITLE
proposed: add gsettings-desktop-schemas as a runtime dependency

### DIFF
--- a/proposed/pantheon.scm
+++ b/proposed/pantheon.scm
@@ -144,6 +144,7 @@ editors, IDEs, etc.")
                (symlink bin link)))))))
     (inputs
      `(("granite" ,granite)
+       ("gsettings-desktop-schemas" ,gsettings-desktop-schemas)
        ("gtk" ,gtk+)
        ("vte" ,vte)))
     (native-inputs


### PR DESCRIPTION
I tested this on my laptop running NixOS and pantheon-terminal fails without
gsettings-desktop-schema.

Here is the failure I get:

(process:1552): GLib-GIO-ERROR **: 13:55:50.606:
Settings schema 'org.gnome.desktop.interface' is not installed
Trace/breakpoint trap (core dumped)

Raghav on matrix:
Regarding that GLib-GIO-ERROR,
I think it is due to missing gsettings-desktop-schemas package